### PR TITLE
Fix challenge links

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -32,4 +32,8 @@ export default defineConfig({
       // ],
     }),
   ],
+  redirects: {
+    "/challenge/challenge": "/challenge",
+    "/challenge/challenge-embedded": "/challenge/embedded",
+  },
 });

--- a/src/content/docs/challenge/embedded.md
+++ b/src/content/docs/challenge/embedded.md
@@ -1,6 +1,7 @@
 ---
 title: Embedded Challenge
 description: Hardened JavaScript Escape Room on Embedded Hardware
+slug: challenge/embedded
 ---
 
 <link rel="stylesheet" href="../index.css">

--- a/src/content/docs/challenge/index.md
+++ b/src/content/docs/challenge/index.md
@@ -1,6 +1,7 @@
 ---
 title: Web Challenge
 description: Hardened JavaScript Escape Room
+slug: challenge
 ---
 
 <link rel="stylesheet" href="../index.css">


### PR DESCRIPTION
Adding the embedded challenge broke some old links. I’ve reconstructed the hierarchy and left redirects to ensure that all extant links find their way home.