### PR TITLE
Add blogs for SES 1.8.0 and 1.9.0

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -17,19 +17,20 @@ export default defineConfig({
       // social: {
       // 	github: 'https://github.com/withastro/starlight',
       // },
-      // sidebar: [
-      // 	{
-      // 		label: 'Guides',
-      // 		items: [
-      // 			// Each item here is one entry in the navigation menu.
-      // 			{ label: 'Example Guide', slug: 'guides/example' },
-      // 		],
-      // 	},
-      // 	{
-      // 		label: 'Reference',
-      // 		autogenerate: { directory: 'reference' },
-      // 	},
-      // ],
+      sidebar: [
+        {
+          label: "Challenge",
+          autogenerate: { directory: "challenge" },
+        },
+        {
+          label: "Console",
+          slug: "console",
+        },
+        {
+          label: "Blog",
+          autogenerate: { directory: "blog" },
+        },
+      ],
     }),
   ],
   redirects: {

--- a/src/content/docs/blog/ses-1.8.0.md
+++ b/src/content/docs/blog/ses-1.8.0.md
@@ -1,0 +1,40 @@
+---
+title: SES 1.8.0 adds flexibility to Lockdown
+date: 2024-08-27
+slug: blog/ses-1.8.0
+---
+
+[Agoric](https://agoric.com) has released `ses` version
+[1.8.0](https://www.npmjs.com/package/ses/v/1.6.0) with more
+implementation-specific options to Hardened JavaScript's `lockdown()` function
+to improve ecosystem compatibility.
+
+### Regenerator Runtime Compatibility
+
+Old versions of some npm packages used
+[`regenerator`](https://github.com/facebook/regenerator) to anticipate
+JavaScript's async functions before language support was ubiquitous.
+These rely on
+[`regenerator-runtime`](https://www.npmjs.com/package/regenerator-runtime) to
+approximate the language feature.
+However, in the few cases where a dependency on versions 0.10.5 to 0.13.7 of
+`regenerator-runtime` persist, applications are incompatible with `ses` due to
+misalignment of the global objects the runtime introduces and the environment
+that Hardened JavaScript expects from the base language.
+
+### Error Trapping: Report
+
+Starting with SES 1.8.0, the `'report'` mode for `errorTrapping` will write
+errors to standard error with the new `SES_UNCAUGHT_EXCEPTION: ` prefix.
+The `'report'` mode is sometimes implied by `'platform'`, `'exit'`, or `'abort'`.
+This is intended to give valuable context to users of the system, especially
+when an uncaught exception is not an `Error` object, and therefore its origin
+may be hard to find in source code.
+
+This is not likely to affect most systems built with SES, as stderr is
+generally reserved for user-only messages.
+If your SES system sends its stderr to a program which parses it, you may need
+to adapt that program to be tolerant of the `SES_UNCAUGHT_EXCEPTION: ` prefix.
+Even for such programs, it is unlikely they are that sensitive to stderr
+formatting.
+

--- a/src/content/docs/blog/ses-1.9.0.md
+++ b/src/content/docs/blog/ses-1.9.0.md
@@ -1,0 +1,67 @@
+---
+title: SES 1.8.0 introduces immutable ArrayBuffers
+date: 2024-10-10
+slug: blog/ses-1.9.0
+---
+
+SES 1.8.0 introduces immutable `ArrayBuffer`, exposes its `console` shim, and permits
+a global `ModuleSource` in the shared intrinsics.
+
+### Immutable ArrayBuffer
+
+Agoric's [Mark Miller](https://agoric.com/team/)
+[presented](https://www.youtube.com/watch?v=CP_5Yo9h84k) a
+[proposal](https://github.com/tc39/proposal-immutable-arraybuffer) at the
+October plenary meeting of the JavaScript standard committee, ECMA TC39.
+The committee adopted Immutable Array Buffers into the body of problems under
+consideration for a solution in a future standard, called "Stage 1".
+
+SES 1.8.0 is the first release to introduce an emulation of the proposed
+immutable ArrayBuffer.
+
+On platforms without
+[`Array.prototype.transfer`](https://github.com/tc39/proposal-resizablearraybuffer)
+but with a global `structuredClone`, the ses-shim's `lockdown` will now install
+an emulation of `Array.prototype.transfer`.
+On platforms with neither, `ses` will *currently* not install such an
+emulation.
+However, once we verify that `ses` is not intended to support platforms without
+both, we may change `lockdown` to throw, failing to lock down.
+
+- XS and Node >= 22 already have `Array.prototype.transfer`.
+- Node 18, Node 20, and all browsers have `structuredClone`
+- Node <= 16 have neither, but are also no longer supported by `ses`.
+
+### Console Shim
+
+The `ses` shim consists of mostly separable layers:
+
+- `ses/assert-shim.js`
+- `ses/lockdown-shim.js`
+- `ses/compartment-shim.js`
+- `ses/console-shim.js`
+
+Version 1.9.0 is the first release to expose an entry point for
+`ses/console-shim.js` so the user can choose whether to wrap and replace the
+global `console` from the hardened JavaScript realm with a version that can
+unredact error messages.
+
+### ModuleSource
+
+Agoric champions a number of JavaScript standard proposals under the umbrellas
+of [Hardened JavaScript](https://github.com/tc39/proposal-ses),
+[Compartments](https://github.com/tc39/proposal-compartments/blob/master/0-module-and-module-source.md),
+and a broad effort toward "Module Harmony".
+These include a proposal for a global `ModuleSource` that takes the source code
+of a JavaScript module and prepares it for evaluation.
+
+The package `@endo/module-source` provides an emulation of a `ModuleSource`
+constructor suitable for use in combination with `ses` and [Moddable's
+XS](https://github.com/Moddable-OpenSource/moddable/blob/public/documentation/xs/XS%20Compartment.md)
+provides a native implementation.
+The module `@endo/module-source/shim.js` can install the emulated `ModuleSource`
+in global scope so it becomes available as a shared intrinsic.
+
+Version 1.9.0 adds `ModuleSource` to the shared intrinsics that `lockdown` will
+repair if necessary and then harden, which consequently is available by default
+in every new `Compartment`.


### PR DESCRIPTION
These are release notes in blog format and include fixes for the sidebar order and appearance.